### PR TITLE
using setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 version = '1.1.1'
 
@@ -28,7 +31,7 @@ setup(name='simplemediawiki',
           'License :: OSI Approved :: GNU Library or Lesser General Public '
           'License (LGPL)',
       ],
-      requires=[
+      install_requires=[
           'kitchen',
           'simplejson',
       ],


### PR DESCRIPTION
You use require in your setup function, this is noch defined see http://docs.python.org/distutils/apiref.html#distutils.core.setup

For providing requirements you have to use setuptools instesad of distutils.core. For documentation see:
http://peak.telecommunity.com/DevCenter/setuptools

Whith this patch, debian can create automatically the requirements.
