### PR TITLE
using LWPCookieJar insted FileCookieJar due to not implemented save()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Thanks to everybody who has contributed to simplemediawiki:
 Ian Weller <iweller@redhat.com>
 Sandro Knauß <bugs@sandroknauss.de>
 Andrew Wang <andrewwang43@gmail.com>
+Tsukasa Hamano <code@cuspy.org>

--- a/simplemediawiki.py
+++ b/simplemediawiki.py
@@ -106,7 +106,7 @@ class MediaWiki(object):
         if cookiejar:
             self._cj = cookiejar
         elif cookie_file:
-            self._cj = cookielib.FileCookieJar(cookie_file)
+            self._cj = cookielib.LWPCookieJar(cookie_file)
             try:
                 self._cj.load()
             except IOError:


### PR DESCRIPTION
I got following error:

```
>>> import simplemediawiki
>>> api = simplemediawiki.MediaWiki("http://example.com/api.php", cookie_file="cookie.txt")
Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
        File "/home/hamano/virtualenv/local/lib/python2.7/site-packages/simplemediawiki.py", line 113, in __init__
          self._cj.save()
        File "/usr/lib/python2.7/cookielib.py", line 1753, in save
          raise NotImplementedError()
      NotImplementedError
```

Perhaps we should use cookielib.LWPCookieJar insted cookielib.FileCookieJar.
Thank you.
