### PR TITLE
Modified constructor if statement

### DIFF
--- a/simplemediawiki.py
+++ b/simplemediawiki.py
@@ -103,9 +103,9 @@ class MediaWiki(object):
         self._api_url = api_url
         self._http_user = http_user
         self._http_password = http_password
-        if cookiejar:
+        if cookiejar != None:
             self._cj = cookiejar
-        elif cookie_file:
+        elif cookie_file != None:
             self._cj = cookielib.FileCookieJar(cookie_file)
             try:
                 self._cj.load()


### PR DESCRIPTION
 Modified if statement to check if cookiejar is not None, because cookiejars support the iterator
protocol. If you create a cookiejar and supply it to the constructor it will have no cookies to
iterate and therefore cookiejar will be 0 and "if cookiejar:" will result in "False".
But you want to use the supplied cookiejar, this happens if you compare it to None.
