### PR TITLE
bug fix: improve detection of 'cookiejar' argument

### DIFF
--- a/simplemediawiki.py
+++ b/simplemediawiki.py
@@ -103,9 +103,9 @@ class MediaWiki(object):
         self._api_url = api_url
         self._http_user = http_user
         self._http_password = http_password
-        if cookiejar:
+        if cookiejar is not None:
             self._cj = cookiejar
-        elif cookie_file:
+        elif cookie_file is not None:
             self._cj = cookielib.LWPCookieJar(cookie_file)
             try:
                 self._cj.load()

--- a/simplemediawiki.py
+++ b/simplemediawiki.py
@@ -109,7 +109,7 @@ class MediaWiki(object):
             self._cj = cookielib.LWPCookieJar(cookie_file)
             try:
                 self._cj.load()
-            except IOError:
+            except cookielib.LoadError:
                 self._cj.save()
                 self._cj.load()
         else:


### PR DESCRIPTION
When passing clean LWPCookieJar() object, it is retyped to False, which resulted in creating new CookieJar(). Comparison to None is necessary.
